### PR TITLE
Add pluck waste edges functions.

### DIFF
--- a/demo/create_graph.py
+++ b/demo/create_graph.py
@@ -133,9 +133,9 @@ def create_node_list(input_node_dict):
 """
 
 
-def pluck_waste_edges(nodes):
+def remove_redundant_dependency(nodes):
     """
-    エッジの間引きを行う。
+    エッジ(依存関係)の間引きを行う。
     各ノードのターゲットから、間引いてよいターゲットを見つけ、間引く。
     Args:
         nodes: 間引きを行いたいノード(1個以上)
@@ -144,8 +144,10 @@ def pluck_waste_edges(nodes):
     node2ancestors = dict()  # key=node, value=keyの全祖先
     for node in nodes:
         make_node2ancestors_recursively(node, node2ancestors)
-        removable_edge_list = search_removable_edges(node, node2ancestors)
-        for source, target in removable_edge_list:
+
+    for node in nodes:
+        removable_dependency_list = search_removable_dependency(node, node2ancestors)
+        for source, target in removable_dependency_list:
             source.targets.remove(target)
             target.sources.remove(source)
 
@@ -159,56 +161,42 @@ def make_node2ancestors_recursively(node, node2ancestors):
         node2ancestors: key=ノード, value=keyの全祖先のセット
     Return:
         nodeにターゲットが存在しない：要素がnodeのみのセット
+        nodeがnode2ancestors.keys()に存在する:node2ancestors[node]
         それ以外：nodeの全祖先のノードのセット
     """
+    if node in node2ancestors:
+        return node2ancestors[node]
+
     if not node.targets:
         node2ancestors[node] = set()
         return {node}
 
     ancestors = set()
     for target in node.targets:
-        ancestors = ancestors | {target}
-        if target in node2ancestors.keys():
-            ancestors = ancestors | node2ancestors[target]
-        else:
-            ancestors = ancestors | make_node2ancestors_recursively(target, node2ancestors)
+        ancestors |= {target}
+        ancestors |= make_node2ancestors_recursively(target, node2ancestors)
     node2ancestors[node] = ancestors
     return ancestors
 
 
-def search_removable_edges(node, node2ancestors):
+def search_removable_dependency(node, node2ancestors):
     """
-    取り除いてもよいエッジを見つける。
+    取り除いてもよいエッジ(依存関係)を見つける。
     Args:
         node: 間引きたいノード(ソース側)。
         node2ancestors: key=nodeのtarget, value=keyの全祖先のノードのセット の辞書。
     Return:
-        thin_out_edge_list: 間引いてよいエッジ(source, target)のリスト。
-                            source,targetはともにNodeオブジェクト。
+        removable_dependency_list: 間引いてよいエッジ(source, target)のリスト。
+                                source,targetはともにNodeオブジェクト。
     """
-    removable_edge_list = list()
-    # node2ancestorsの中からkeyがnode.targets内に存在するもののみ取ってくる。
-    target2ancestors = \
-        {target: ancestors for target, ancestors in node2ancestors.items() if target in node.targets}
-    target_route_union = make_union_by_dict_value(target2ancestors)
+    removable_dependency_list = list()
+    all_target_ancestors = set()
     for target in node.targets:
-        if target in target_route_union:
-            removable_edge_list.append((node, target))
-    return removable_edge_list
-
-
-def make_union_by_dict_value(set_dict):
-    """
-    valueにセットを持つ辞書の和集合を作成する。
-    Args:
-        set_dict: セットを値に持つ辞書
-    Return:
-        set_union: set_dictの値の和集合
-    """
-    set_union = set()
-    for v in set_dict.values():
-        set_union = set_union | v
-    return set_union
+        all_target_ancestors |= node2ancestors[target]
+    for target in node.targets:
+        if target in all_target_ancestors:
+            removable_dependency_list.append((node, target))
+    return removable_dependency_list
 
 
 """

--- a/demo/create_graph.py
+++ b/demo/create_graph.py
@@ -582,7 +582,7 @@ def main():
                        }
 
     node_list = create_node_list(shuffle_dict(input_node_dict))
-    pluck_waste_edges(node_list)
+    remove_redundant_dependency(node_list)
     assign_top_node(node_list)
     assign_x_sequentially(node_list)
     cut_edges_higher_than_1(node_list)


### PR DESCRIPTION
間引きを行う関数の追加。
・pluck_waste_edges( ): 間引くエッジを除去する。
・make_node2ancestors_recursively(): keyがノードでvalueがノードの全祖先となる辞書を作る。
・search_removable_edges(): 間引けるエッジを探す。
・make_union_by_dict_value(): 値がセットの辞書から、全値の和集合を作成する。