### PR TITLE
Initial commit. Create retrieve_environment.py.

### DIFF
--- a/retrieve_environment.py
+++ b/retrieve_environment.py
@@ -1,9 +1,10 @@
 import os
 import glob
 from pathlib import Path
+MIZAR_LIBRARY_DIRECTORY_PATH = Path("mml")
 
 
-def make_library_dependence():
+def make_library_dependency():
     """
     各カテゴリ内で参照しているファイルを取得する。
     Args:
@@ -26,10 +27,12 @@ def make_library_dependence():
     for category in categories:
         miz_files_dict[category] = dict()
 
-    path = Path("mml")
-    os.chdir(path)
-    miz_files = glob.glob("*.miz")  # mmlディレクトリの.mizファイルを取り出す
+    cwd = os.getcwd()
+    try:
+        os.chdir(MIZAR_LIBRARY_DIRECTORY_PATH)
+        miz_files = glob.glob("*.miz")  # mmlディレクトリの.mizファイルを取り出す
 
-    os.chdir("../")
+    finally:
+        os.chdir(cwd)
 
     return miz_files_dict

--- a/retrieve_environment.py
+++ b/retrieve_environment.py
@@ -1,0 +1,35 @@
+import os
+import glob
+from pathlib import Path
+
+
+def make_library_dependence():
+    """
+    各カテゴリ内で参照しているファイルを取得する。
+    Args:
+    Return:
+        miz_file_dict: 各カテゴリ(vocabularies, constructors等)において、各ライブラリが
+                       どのライブラリを参照しているかを示す辞書。
+                       例：lib_aがlib_x, lib_y, ... をvocabulariesで参照している場合、
+                        miz_file_dict = {
+                            'vocabularies': {
+                                'lib_a': {'lib_x', 'lib_y', ...},
+                                ...
+                            }
+                            'constructors': { ... },
+                            ...
+                        }
+    """
+    miz_files_dict = dict()
+    categories = ['vocabularies', 'constructors', 'notations', 'registrations', 'theorems', 'schemes',
+                  'definitions', 'requirements', 'expansions', 'equalities']
+    for category in categories:
+        miz_files_dict[category] = dict()
+
+    path = Path("mml")
+    os.chdir(path)
+    miz_files = glob.glob("*.miz")  # mmlディレクトリの.mizファイルを取り出す
+
+    os.chdir("../")
+
+    return miz_files_dict


### PR DESCRIPTION
issue: Search mizar dependency.  #21
mizarファイルから環境部を取り出すプログラムの作成をしました。
make_library_dependence(): ライブラリの依存関係を示す辞書の作成（初期化）を行う。mizarライブラリファイルが格納されているディレクトリへアクセスし、.mizファイルを取得する。