### PR TITLE
Fix bug for assign_level2node_recursively().

### DIFF
--- a/demo/create_graph.py
+++ b/demo/create_graph.py
@@ -242,6 +242,7 @@ def assign_level2node_recursively(node_list, target, target_level):
             assign_level2node_recursively(node_list, assign_node, assign_node_level)
         elif assign_node.x > -1 and assign_node.y <= assign_node_level:
             assign_node.y = assign_node_level
+            assign_level2node_recursively(node_list, assign_node, assign_node_level)
 
 
 def assign_x_sequentially(node_list):


### PR DESCRIPTION
issue: assign_level2node_recursively()のバグ #17
assign_level2node_recursively()のバグを修正しました。
これがないと、正しくグラフの階層割当が行えません。
詳しくは、issueで記述しています。